### PR TITLE
Removed - Deadlink

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,7 +203,6 @@ If there is need for a device with graphics card, it is highly recommended to ge
 
 ## Cyber Security
 
-- [General CTF Learning Resources - InCTF](https://resources.bi0s.in)
 - [bi0s wiki](https://wiki.bi0s.in)
 - [Cyber Security Resources](https://github.com/NAVHITS/cyber-security-resources)
 


### PR DESCRIPTION
[General CTF Learning Resources - InCTF](https://resources.bi0s.in)
Was removed because the page doesn't exist anymore